### PR TITLE
Fix config file names in READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ YunMin-mamba-training/
 ```
 
 Set the `MODEL_CONFIG_PATH` environment variable to point to either
-`configs/mamba_3b.json` or `configs/mamba_7b.json` to choose which model size
+`configs/mamba_config.json` or `configs/mamba_7b_config.json` to choose which model size
 to train.
 
 ## Model Architecture

--- a/README_SAGEMAKER.md
+++ b/README_SAGEMAKER.md
@@ -32,8 +32,8 @@ YunMin-mamba-training/
     └── python-tests.yml
 ```
 
-`MODEL_CONFIG_PATH` 환경 변수를 `configs/mamba_3b.json` 또는
-`configs/mamba_7b.json`으로 설정하면 3B와 7B 중 원하는 모델을 선택할 수
+`MODEL_CONFIG_PATH` 환경 변수를 `configs/mamba_config.json` 또는
+`configs/mamba_7b_config.json`으로 설정하면 3B와 7B 중 원하는 모델을 선택할 수
 있습니다.
 
 ## 🚀 Quick Start


### PR DESCRIPTION
## Summary
- update README references to `mamba_config.json`
- update Korean README references to `mamba_config.json`
- search repository for any mentions of the old file name

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68404a95c094833387acf3e1c0189090