### PR TITLE
Fix dockerignore for new Dockerfile path

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -52,5 +52,5 @@ README.md
 *.md
 
 # Docker
-Dockerfile
+docker/Dockerfile
 .dockerignore 


### PR DESCRIPTION
## Summary
- update `.dockerignore` to ignore `docker/Dockerfile`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68404a987bf48333aff15b9d26d288af