### PR TITLE
Fix architecture link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ to train.
 
 ## Model Architecture
 
-The configuration file `configs/mamba_config.json` defines the 3B model with 36 layers and a hidden size of 2,560.  A larger 7B variant is provided in `configs/mamba_7b_config.json` with 32 layers and a hidden size of 4,096.  Gradient checkpointing and DeepSpeed ZeRO Stage 2 are enabled during training to keep GPU memory usage manageable.  See [architecture.md](architecture.md) for the original training plan.
+The configuration file `configs/mamba_config.json` defines the 3B model with 36 layers and a hidden size of 2,560.  A larger 7B variant is provided in `configs/mamba_7b_config.json` with 32 layers and a hidden size of 4,096.  Gradient checkpointing and DeepSpeed ZeRO Stage 2 are enabled during training to keep GPU memory usage manageable. 
 
 ## Dataset Layout
 


### PR DESCRIPTION
## Summary
- drop reference to the removed architecture.md file

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68404a9c80188333b8ef299afa29f7ff