### PR TITLE
Fix mamba install issue in Dockerfile

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -15,6 +15,7 @@ ENV DEBIAN_FRONTEND=noninteractive \
     LD_LIBRARY_PATH=/usr/local/cuda/lib64:$LD_LIBRARY_PATH \
     TOKENIZERS_PARALLELISM=false \
     MAX_JOBS=4 \
+    MAMBA_SKIP_CUDA_BUILD=1 \
     PYTHONPATH=/app
 
 # ========= System packages =========


### PR DESCRIPTION
## Summary
- add `MAMBA_SKIP_CUDA_BUILD` env variable in the Dockerfile so mamba-ssm installs without building CUDA kernels

## Testing
- `pytest -q`
- `docker build -t test-mamba -f docker/Dockerfile docker` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68405db903bc83338856d47e3aad3665