### PR TITLE
Update Docker build notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,10 @@ includes dataset paths, S3 output locations and common hyperparameters such as
 
 1. **Push the Docker image to ECR**:
 
+   The Dockerfile already sets `MAMBA_SKIP_CUDA_BUILD=1`, so the Mamba CUDA
+   kernels are skipped automatically. You can build the image even on a
+   CPU‑only machine.
+
    ```bash
    aws sts get-caller-identity
    docker build -f docker/Dockerfile -t <your-image> .

--- a/README_SAGEMAKER.md
+++ b/README_SAGEMAKER.md
@@ -53,6 +53,10 @@ docker tag <your-image> <ECR_URI>
 docker push <ECR_URI>
 ```
 
+Dockerfile 내부에서 `MAMBA_SKIP_CUDA_BUILD=1`이 설정되어 있어 CUDA 커널
+빌드를 자동으로 건너뜁니다. 따라서 GPU가 없는 환경에서도 이미지를 빌드할
+수 있습니다.
+
 ### 2. 데이터 준비
 
 S3에 다음 구조로 데이터를 업로드하세요:


### PR DESCRIPTION
## Summary
- document that MAMBA_SKIP_CUDA_BUILD is set in the Dockerfile
- mention CPU-only machines can build the image

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684065612fcc83338ba00feb88b00225