### PR TITLE
Add CUDA kernel skip comment

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -7,6 +7,7 @@ ARG UBUNTU_VERSION=22.04
 FROM nvidia/cuda:${CUDA_VERSION}-cudnn${CUDNN_VERSION}-devel-ubuntu${UBUNTU_VERSION}
 
 # ========= Environment setup =========
+# Skip building CUDA kernels for Mamba
 ENV DEBIAN_FRONTEND=noninteractive \
     HF_HOME=/root/.cache/huggingface \
     PYTHONUNBUFFERED=1 \


### PR DESCRIPTION
## Summary
- clarify that `MAMBA_SKIP_CUDA_BUILD` skips CUDA kernels in the Dockerfile

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68406562490883338b1a3a0164506bc7