### PR TITLE
Add dataset path CLI option

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,11 @@ includes dataset paths, S3 output locations and common hyperparameters such as
    ```
 
    The script creates a training job using Spot instances and resumes from the latest checkpoint when interrupted.
+   You can also run the training script directly and override the dataset directory:
+
+   ```bash
+   python src/train_mamba.py --dataset-path /path/to/data
+   ```
 
 For additional configuration options and dataset layout, see [README_SAGEMAKER.md](README_SAGEMAKER.md).
 

--- a/README_SAGEMAKER.md
+++ b/README_SAGEMAKER.md
@@ -145,6 +145,8 @@ SageMaker 훈련 작업에서 다음 하이퍼파라미터를 설정할 수 있�
 - `SM_OUTPUT_DATA_DIR`: 출력 데이터 경로
 - `/opt/ml/input/config/hyperparameters.json`: 하이퍼파라미터
 
+`src/train_mamba.py` 를 직접 실행할 때는 `--dataset-path` 옵션으로 `SM_CHANNEL_TRAINING` 값을 덮어쓸 수 있습니다.
+
 ## 📁 Output Structure
 
 훈련 완료 후 다음과 같은 구조로 결과가 저장됩니다:

--- a/src/train_mamba.py
+++ b/src/train_mamba.py
@@ -401,6 +401,11 @@ def main():
         default=None,
         help="Path to the model configuration JSON file",
     )
+    parser.add_argument(
+        "--dataset-path",
+        default=None,
+        help="Optional local path to the dataset directory",
+    )
     args, _ = parser.parse_known_args()
     # Set PyTorch memory optimization
     os.environ['PYTORCH_CUDA_ALLOC_CONF'] = 'expandable_segments:True'
@@ -432,7 +437,8 @@ def main():
         or hyperparams.get("model_config_path")
         or os.environ.get("MODEL_CONFIG_PATH", "configs/mamba_config.json")
     )
-    dataset_path = input_path
+    dataset_path = args.dataset_path or input_path
+    logger.info(f"Dataset path resolved to: {dataset_path}")
 
     # Separate directories for checkpoints and final model
     checkpoint_root = os.environ.get('SM_CHECKPOINT_DIR', '/opt/ml/checkpoints')

--- a/tests/test_train_cli.py
+++ b/tests/test_train_cli.py
@@ -20,3 +20,4 @@ def test_train_mamba_parses_model_config():
     )
     assert result.returncode == 0
     assert "model-config-path" in result.stdout
+    assert "dataset-path" in result.stdout


### PR DESCRIPTION
## Summary
- parse a new `--dataset-path` argument
- default dataset path to `SM_CHANNEL_TRAINING` when the argument isn't used
- document the new option in README files
- test that CLI help lists `dataset-path`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68406de120d48333b310d312c68de835