### PR TITLE
Fix mamba build failure by aligning PyTorch version

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -36,7 +36,7 @@ WORKDIR /app
 RUN pip install --upgrade pip setuptools wheel ninja packaging numpy
 
 # 2) Install PyTorch for CUDA 12.1
-RUN pip install torch==2.2.2 torchvision==0.17.2 torchaudio==2.2.2 --index-url https://download.pytorch.org/whl/cu121
+RUN pip install torch==2.1.2 torchvision==0.16.2 torchaudio==2.1.2 --index-url https://download.pytorch.org/whl/cu121
 
 # 3) Install base deps
 RUN pip install --no-cache-dir -r requirements.txt

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
-torch==2.2.2
-torchvision==0.17.2
-torchaudio==2.2.2
+torch==2.1.2
+torchvision==0.16.2
+torchaudio==2.1.2
 transformers>=4.39.3
 tokenizers==0.15.2
 huggingface-hub==0.23.0


### PR DESCRIPTION
## Summary
- downgrade PyTorch and related packages to 2.1 series
- update Dockerfile to use torch 2.1.x for CUDA 12.1

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684072b0dea083339730aa631e4faa42