### PR TITLE
Enable ZeRO‑3 and bf16 training

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ to train.
 
 ## Model Architecture
 
-The configuration file `configs/mamba_3b_config.json` defines the 3B model with 36 layers and a hidden size of 2,560.  A larger 7B variant is provided in `configs/mamba_7b_config.json` with 32 layers and a hidden size of 4,096.  Gradient checkpointing and DeepSpeed ZeRO Stage 2 are enabled during training to keep GPU memory usage manageable. 
+The configuration file `configs/mamba_3b_config.json` defines the 3B model with 36 layers and a hidden size of 2,560.  A larger 7B variant is provided in `configs/mamba_7b_config.json` with 32 layers and a hidden size of 4,096.  Gradient checkpointing and DeepSpeed ZeRO Stage 3 with bf16 are enabled during training to keep GPU memory usage manageable.
 
 ## Dataset Layout
 

--- a/architecture.md
+++ b/architecture.md
@@ -2,7 +2,7 @@
 
 This project trains Mamba-based language models using HuggingFace Accelerate and DeepSpeed. The 3B model
 uses 36 layers with a hidden size of 2,560, while the optional 7B variant uses 32 layers and a hidden size
-of 4,096. Gradient checkpointing and ZeRO Stage 2 keep GPU memory usage manageable.
+of 4,096. Gradient checkpointing and ZeRO Stage 3 with bf16 keep GPU memory usage manageable.
 
 Datasets are processed in a curriculum order: `main_data`, `korean_textbook`, `academic_data`, `papers_data`,
 `national_data`, `national_assembly_data`, `web_data`, and `social_media_data`. The `train_mamba.py` script

--- a/configs/accelerate_config.yaml
+++ b/configs/accelerate_config.yaml
@@ -2,12 +2,12 @@ compute_environment: LOCAL_MACHINE
 debug: false
 deepspeed_config:
   deepspeed_config_file: /app/deepspeed_config.json
-  zero3_init_flag: false
+  zero3_init_flag: true
 distributed_type: DEEPSPEED
 downcast_bf16: 'no'
 machine_rank: 0
 main_training_function: main
-mixed_precision: fp16
+mixed_precision: bf16
 num_machines: 1
 num_processes: 8
 rdzv_backend: static

--- a/configs/deepspeed_config.json
+++ b/configs/deepspeed_config.json
@@ -1,6 +1,6 @@
 {
   "fp16": {
-    "enabled": true,
+    "enabled": false,
     "loss_scale": 0,
     "loss_scale_window": 1000,
     "initial_scale_power": 16,
@@ -9,7 +9,7 @@
   },
   
   "bf16": {
-    "enabled": false
+    "enabled": true
   },
 
   "optimizer": {
@@ -32,7 +32,11 @@
   },
 
   "zero_optimization": {
-    "stage": 2,
+    "stage": 3,
+    "offload_param": {
+      "device": "cpu",
+      "pin_memory": true
+    },
     "offload_optimizer": {
       "device": "cpu",
       "pin_memory": true

--- a/configs/mamba_3b_config.json
+++ b/configs/mamba_3b_config.json
@@ -12,7 +12,7 @@
     "bos_token_id": 1,
     "eos_token_id": 2,
     "tie_word_embeddings": false,
-    "torch_dtype": "float16",
+    "torch_dtype": "bfloat16",
     "model_type": "mamba",
     "attn_layernorm": true,
     "rms_norm_eps": 1e-05,

--- a/configs/mamba_7b_config.json
+++ b/configs/mamba_7b_config.json
@@ -12,7 +12,7 @@
     "bos_token_id": 1,
     "eos_token_id": 2,
     "tie_word_embeddings": false,
-    "torch_dtype": "float16",
+    "torch_dtype": "bfloat16",
     "model_type": "mamba",
     "attn_layernorm": true,
     "rms_norm_eps": 1e-05,

--- a/src/train_mamba.py
+++ b/src/train_mamba.py
@@ -144,7 +144,7 @@ def train_on_category(accelerator, model, tokenizer, category_dataset, category,
     logger.info(f"🚀 Starting training on {category}...")
     
     # DeepSpeed handles gradient accumulation automatically
-    logger.info(f"Training config: batch_size={batch_size}, using DeepSpeed ZeRO Stage 2")
+    logger.info(f"Training config: batch_size={batch_size}, using DeepSpeed ZeRO Stage 3")
     
     # Create DataLoader for this category
     train_dataloader = DataLoader(
@@ -486,7 +486,7 @@ def main():
         logger.info("📂 No checkpoint directory found - starting fresh training")
     
     logger.info(f"Hyperparameters: lr={learning_rate}, batch_size={batch_size}, max_seq_length={max_seq_length}, save_steps={save_steps}")
-    logger.info(f"🔧 Using DeepSpeed ZeRO Stage 2 with optimizer offloading for memory efficiency")
+    logger.info(f"🔧 Using DeepSpeed ZeRO Stage 3 with optimizer offloading for memory efficiency")
     
     if resume_from_checkpoint and os.path.exists(resume_from_checkpoint):
         logger.info(f"🔄 Found checkpoint at {resume_from_checkpoint}. Will load after initialization")


### PR DESCRIPTION
## Summary
- update Deepspeed configuration to enable bf16 and ZeRO Stage 3 with parameter offload
- switch Accelerate config to bf16 and enable ZeRO-3 init
- set `torch_dtype` to `bfloat16` for both model configs
- fix training logs to mention ZeRO Stage 3
- documentation updates mentioning ZeRO Stage 3 with bf16

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6842f1931a18833381c2e49ce22aa090